### PR TITLE
typo: Rename US Georgia subdivision northweast to northwest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1336,7 +1336,7 @@ Total elements: 476
 | northern_mariana_islands                 | oceania                          | northern_mariana_islands                 | sPp     |
 | northern_mindanao                        | philippines                      | northern_mindanao                        | sPp     |
 | northern_territory                       | australia                        | northern_territory                       | sPp     |
-| northweast                               | georgia                          | northweast                               | sPp     |
+| northwest                                | georgia                          | northwest                                | sPp     |
 | northwest_territories                    | canada                           | northwest_territories                    | sPp     |
 | northwestern_federal_district            | russia                           | northwestern_federal_district            | sPp     |
 | northwestern_ontario                     | ontario                          | northwestern_ontario                     | sPp     |

--- a/openstreetmap.fr.yml
+++ b/openstreetmap.fr.yml
@@ -6701,10 +6701,10 @@ elements:
             - osm.pbf
             - state
             - poly
-    northweast:
-        id: northweast
-        file: northweast
-        name: northweast
+    northwest:
+        id: northwest
+        file: northwest
+        name: northwest
         parent: georgia
         files:
             - poly


### PR DESCRIPTION
https://github.com/osm-fr/osmose-backend/pull/2245